### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setuptools.setup(
     description="Lutron Homeworks Series 4 and 8 interface over Ethernet",
     long_description=long_description,
     long_description_content_type="text/markdown",
+    license="MIT",
     url="https://github.com/dubnom/pyhomeworks",
     packages=setuptools.find_packages(),
     classifiers=[


### PR DESCRIPTION
Allow third-party tools (e.g, PyPI) to get the license in an easy way.