### PR TITLE
Don't connect or start thread from Homeworks constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ The controller is connected by an RS232 port to an Ethernet adaptor (NPort).
         print(msg,data)
 
     hw = Homeworks( 'host.test.com', 4008, callback )
+    hw.start()
 
     # Sleep for 10 seconds waiting for a callback
     sleep(10.)
 
-    # Close the interface
-    hw.close()
+    # Close the interface and stop the worker thread
+    hw.stop()

--- a/examples/test.py
+++ b/examples/test.py
@@ -14,11 +14,12 @@ def callback(msg, args):
 
 print("Starting interace")
 hw = Homeworks('192.168.2.55', 4008, callback)
+hw.start()
 
 print("Connected. Waiting for messages.")
 time.sleep(10.)
 
 print("Closing.")
-hw.close()
+hw.stop()
 
 print("Done.")

--- a/pyhomeworks/exceptions.py
+++ b/pyhomeworks/exceptions.py
@@ -5,5 +5,9 @@ class HomeworksException(Exception):
     """Base class for exceptions."""
 
 
+class HomeworksConnectionFailed(HomeworksException):
+    """Connection failed."""
+
+
 class HomeworksConnectionLost(HomeworksException):
     """Connection lost."""

--- a/pyhomeworks/pyhomeworks.py
+++ b/pyhomeworks/pyhomeworks.py
@@ -101,7 +101,11 @@ class Homeworks(Thread):
         self._running = False
 
     def connect(self) -> None:
-        """Connect to controller using host, port."""
+        """Connect to controller using host, port.
+
+        It's not necessary to call this method, but it can be useed to attempt to
+        connect to the remote device without starting the worker thread.
+        """
         self._connect()
 
     def _connect(self) -> None:

--- a/pyhomeworks/pyhomeworks.py
+++ b/pyhomeworks/pyhomeworks.py
@@ -168,7 +168,7 @@ class Homeworks(Thread):
         while self._running:  # pylint: disable=too-many-nested-blocks
             if self._socket is None:
                 with suppress(exceptions.HomeworksException):
-                    self._connect(True)
+                    self._connect()
             else:
                 try:
                     buffer += self._read()

--- a/pyhomeworks/pyhomeworks.py
+++ b/pyhomeworks/pyhomeworks.py
@@ -9,6 +9,7 @@ Michael Dubno - 2018 - New York
 """
 
 from collections.abc import Callable
+from contextlib import suppress
 import logging
 import select
 import socket
@@ -90,7 +91,7 @@ class Homeworks(Thread):
     def __init__(
         self, host: str, port: int, callback: Callable[[Any, Any], None]
     ) -> None:
-        """Connect to controller using host, port."""
+        """Initialize."""
         Thread.__init__(self)
         self._host = host
         self._port = port
@@ -98,21 +99,33 @@ class Homeworks(Thread):
         self._socket: socket.socket | None = None
 
         self._running = False
+
+    def connect(self) -> None:
+        """Connect to controller using host, port."""
         self._connect()
-        if self._socket is None:
-            raise ConnectionError(f"Couldn't connect to '{host}:{port}'")
-        self.start()
 
     def _connect(self) -> None:
+        """Connect to controller using host, port."""
         try:
             self._socket = socket.create_connection(
                 (self._host, self._port), self.SOCKET_CONNECT_TIMEOUT
             )
-            # Setup interface and subscribe to events
-            self._subscribe()
-            _LOGGER.info("Connected to %s:%d", self._host, self._port)
-        except (BlockingIOError, ConnectionError, TimeoutError):
-            pass
+        except (OSError, ValueError) as error:
+            _LOGGER.debug(
+                "Failed to connect to %s:%s - %s",
+                self._host,
+                self._port,
+                error,
+                exc_info=True,
+            )
+            raise exceptions.HomeworksConnectionFailed(
+                f"Couldn't connect to '{self._host}:{self._port}'"
+            ) from error
+
+        _LOGGER.info("Connected to '%s:%s'", self._host, self._port)
+
+        # Setup interface and subscribe to events
+        self._subscribe()
 
     def _read(self) -> bytes:
         readable, _, _ = select.select([self._socket], [], [], self.POLLING_FREQ)
@@ -150,7 +163,8 @@ class Homeworks(Thread):
         buffer = b""
         while self._running:  # pylint: disable=too-many-nested-blocks
             if self._socket is None:
-                self._connect()
+                with suppress(exceptions.HomeworksException):
+                    self._connect(True)
             else:
                 try:
                     buffer += self._read()
@@ -175,6 +189,7 @@ class Homeworks(Thread):
                     if self._running:
                         time.sleep(self.POLLING_FREQ)
 
+        self._running = False
         self._close()
 
     def _process_received_data(self, data_b: bytes) -> None:
@@ -199,15 +214,22 @@ class Homeworks(Thread):
 
     def close(self) -> None:
         """Close the connection to the controller."""
-        self._running = False
+        if self._running:
+            raise exceptions.HomeworksException(
+                "Can't call close when thread is running"
+            )
         self._close()
 
     def _close(self) -> None:
         """Close the connection to the controller."""
         if self._socket:
-            time.sleep(self.POLLING_FREQ)
             self._socket.close()
             self._socket = None
+
+    def stop(self) -> None:
+        """Wait for the worker thread to stop."""
+        self._running = False
+        self.join()
 
     def _subscribe(self) -> None:
         # Setup interface and subscribe to events


### PR DESCRIPTION
Don't connect or start thread from `Homeworks` constructor

Instead, the worker thread, which automatically connects to the remote device is started by calling `Homeworks.start()`
Also, to request the worker thread to stop, the new method `Homeworks.stop()` should be called