### PR TITLE
Fix issue with unsupported floats

### DIFF
--- a/pyhomeworks/pyhomeworks.py
+++ b/pyhomeworks/pyhomeworks.py
@@ -194,9 +194,14 @@ class Homeworks(Thread):
     def fade_dim(
         self, intensity: float, fade_time: float, delay_time: float, addr: str
     ) -> None:
-        """Change the brightness of a light."""
+        """Change the brightness of a light.
+
+        Intensity, fade_time and delay_time are rounded because some controllers
+        don't accept decimals.
+        """
         self._send(
-            f"FADEDIM, {round(intensity)}, {round(fade_time)}, {round(delay_time)}, {addr}"
+            "FADEDIM, "
+            f"{round(intensity)}, {round(fade_time)}, {round(delay_time)}, {addr}"
         )
 
     def request_dimmer_level(self, addr: str) -> None:

--- a/pyhomeworks/pyhomeworks.py
+++ b/pyhomeworks/pyhomeworks.py
@@ -106,7 +106,7 @@ class Homeworks(Thread):
         """Initialize."""
         Thread.__init__(self)
         self._host = host
-        self._port = port
+        self._port = int(port)
         self._credentials = _format_credentials(username, password)
         self._callback = callback
         self._socket: socket.socket | None = None
@@ -195,7 +195,9 @@ class Homeworks(Thread):
         self, intensity: float, fade_time: float, delay_time: float, addr: str
     ) -> None:
         """Change the brightness of a light."""
-        self._send(f"FADEDIM, {intensity}, {fade_time}, {delay_time}, {addr}")
+        self._send(
+            f"FADEDIM, {round(intensity)}, {round(fade_time)}, {round(delay_time)}, {addr}"
+        )
 
     def request_dimmer_level(self, addr: str) -> None:
         """Request the controller to return brightness."""


### PR DESCRIPTION
Fix issue with unsupported floats:
- Convert port number to int in case they pass us a float
- Round `FADEDIM` parameters, some controllers don't accept decimals

Related HA Core issue: https://github.com/home-assistant/core/issues/115612